### PR TITLE
Avoid job submission timeouts from Topology.events() users.

### DIFF
--- a/connectors/mqtt/src/test/java/quarks/test/connectors/mqtt/MqttOpenTest.java
+++ b/connectors/mqtt/src/test/java/quarks/test/connectors/mqtt/MqttOpenTest.java
@@ -52,9 +52,7 @@ public class MqttOpenTest extends MqttStreamsTestManual {
     }
     
     @Ignore
-    public void testIdleSubscribe() {}
+    public void testIdleSubscribe() {}  // intermittent (timing related?) failures
     @Ignore
-    public void testIdlePublish() {}
-    @Ignore
-    public void testConnectFail() {}
+    public void testIdlePublish() {}  // intermittent (timing related?) failures
 }


### PR DESCRIPTION
Move Events oplet's call to eventHandler.accept() to the endlessEventSource thread.
Fix issue #47 and #30 
@ddebrunner & @vdogaru - +1 on the change/merge?
