### PR TITLE
#36 fix: unit tests show stack traces

### DIFF
--- a/api/topology/src/test/java/quarks/test/topology/TStreamTest.java
+++ b/api/topology/src/test/java/quarks/test/topology/TStreamTest.java
@@ -561,7 +561,7 @@ public abstract class TStreamTest extends TopologyAbstractTest {
                 Topology t = newTopology();
                 TStream<String> s = t.strings("a", "b", "c", "d", "e", "f", "g", "h");
                 // Throw on the 8th tuple
-                s.sink((tuple) -> { if ("h".equals(tuple)) throw new RuntimeException("user stopped");});
+                s.sink((tuple) -> { if ("h".equals(tuple)) throw new RuntimeException("Expected Test Exception");});
                 // Expect 7 tuples out of 8
                 Condition<Long> tc = t.getTester().tupleCount(s, 7);
                 complete(t, tc);
@@ -586,7 +586,7 @@ public abstract class TStreamTest extends TopologyAbstractTest {
                 AtomicLong n = new AtomicLong(0);
                 TStream<Long> s = t.poll(() -> n.incrementAndGet(), 10, TimeUnit.MILLISECONDS);
                 // Throw on the 8th tuple
-                s.sink((tuple) -> { if (8 == n.get()) throw new RuntimeException("user stopped");});
+                s.sink((tuple) -> { if (8 == n.get()) throw new RuntimeException("Expected Test Exception");});
                 // Expect 7 tuples out of 8
                 Condition<Long> tc = t.getTester().tupleCount(s, 7);
                 complete(t, tc);

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/TrackingScheduledExecutor.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/TrackingScheduledExecutor.java
@@ -18,6 +18,9 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import quarks.function.BiConsumer;
 
 /**
@@ -30,6 +33,7 @@ import quarks.function.BiConsumer;
  */
 public final class TrackingScheduledExecutor extends ScheduledThreadPoolExecutor {
     private final BiConsumer<Object, Throwable> completer;
+    private static final Logger logger = LoggerFactory.getLogger(TrackingScheduledExecutor.class);
 
     /**
      * Creates an {@code TrackingScheduledExecutor} using the supplied thread 
@@ -66,12 +70,8 @@ public final class TrackingScheduledExecutor extends ScheduledThreadPoolExecutor
             t = unwrapFutureThrowable((Future<?>) r);
         }
         if (t != null) {
-            // TODO trace error
-            synchronized(System.err) {
-                System.err.println("Thread: " + Thread.currentThread().getName() +
-                        ": task terminated with exception : " + t);
-                t.printStackTrace();
-            }
+            getLogger().error("Thread: " + Thread.currentThread().getName() +
+                    ": task terminated with exception : ", t);
             cleanup();
             completer.accept(this, t);
         }
@@ -166,6 +166,10 @@ public final class TrackingScheduledExecutor extends ScheduledThreadPoolExecutor
             }
         }
         return null;
+    }
+
+    private Logger getLogger() {
+        return logger;
     }
 
     /**

--- a/runtime/etiao/src/test/java/quarks/test/runtime/etiao/EtiaoGraphTest.java
+++ b/runtime/etiao/src/test/java/quarks/test/runtime/etiao/EtiaoGraphTest.java
@@ -97,7 +97,6 @@ public class EtiaoGraphTest extends GraphTest {
         
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String json = gson.toJson(new GraphType(g));
-        System.out.println(json);
         
         GraphType gt2 = new Gson().fromJson(json, GraphType.class);
         assertEquals(5, gt2.getVertices().size());
@@ -152,7 +151,6 @@ public class EtiaoGraphTest extends GraphTest {
 
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         String json = gson.toJson(new GraphType(g));
-        System.out.println(json);
         
         GraphType gt = new Gson().fromJson(json, GraphType.class);
         assertEquals(5, gt.getVertices().size());


### PR DESCRIPTION
- Exceptions injected into TStreamTest have the explanatory message "Expected Test Exception".
- On handling an uncaught exception, the system logs an error instead of printing it to System.err.  Note that if logging is configured to write to the ConsoleHandler then messages will be still written to System.err, however they now get written in the proper logs.
- Also, I removed graph representations from the EtiaoGraphTest System.out as they were not needed for test diagnostics.
