### PR TITLE
add slf4j-jdk14 to the unit test classpath

### DIFF
--- a/analytics/math3/build.xml
+++ b/analytics/math3/build.xml
@@ -27,6 +27,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 	
 </project>

--- a/analytics/sensors/build.xml
+++ b/analytics/sensors/build.xml
@@ -24,6 +24,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 	
 </project>

--- a/android/hardware/build.xml
+++ b/android/hardware/build.xml
@@ -29,6 +29,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
  <target name="all" if="env.ANDROID_SDK_PLATFORM">

--- a/android/topology/build.xml
+++ b/android/topology/build.xml
@@ -29,6 +29,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
  <target name="all" if="env.ANDROID_SDK_PLATFORM">

--- a/api/execution/build.xml
+++ b/api/execution/build.xml
@@ -20,7 +20,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/api/function/build.xml
+++ b/api/function/build.xml
@@ -18,7 +18,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-	
 
 </project>

--- a/api/graph/build.xml
+++ b/api/graph/build.xml
@@ -19,7 +19,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/api/oplet/build.xml
+++ b/api/oplet/build.xml
@@ -21,7 +21,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-	
 
 </project>

--- a/api/topology/build.xml
+++ b/api/topology/build.xml
@@ -22,7 +22,7 @@
     <pathelement location="${jar}" />
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/api/window/build.xml
+++ b/api/window/build.xml
@@ -20,6 +20,7 @@
     <pathelement location="${jar}" />
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
 </project>

--- a/common-build.xml
+++ b/common-build.xml
@@ -74,6 +74,11 @@
       <pathelement location="${target.java8.ext}/slf4j-1.7.12/slf4j-jdk14-1.7.12.jar"/>
     </path>
 
+    <!-- Quarks unit tests common class path -->
+    <path id="test.common.classpath">
+      <pathelement location="${target.java8.ext}/slf4j-1.7.12/slf4j-jdk14-1.7.12.jar"/>
+    </path>
+
     <!-- expects a property of component.path e.g. connectors/iotf -->
     <!-- only called by non-core components -->
     <macrodef name="setup.component">

--- a/connectors/common/build.xml
+++ b/connectors/common/build.xml
@@ -24,7 +24,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/file/build.xml
+++ b/connectors/file/build.xml
@@ -27,7 +27,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/http/build.xml
+++ b/connectors/http/build.xml
@@ -26,7 +26,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/iot/build.xml
+++ b/connectors/iot/build.xml
@@ -25,7 +25,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/iotf/build.xml
+++ b/connectors/iotf/build.xml
@@ -16,7 +16,6 @@
     <fileset dir="${component.ext}/lib" includes="*.jar"/>
   </path>
 
-
   <path id="test.compile.classpath">
     <pathelement location="${jar}" />
     <pathelement location="${lib}/quarks.providers.direct.jar"/>
@@ -28,7 +27,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/jdbc/build.xml
+++ b/connectors/jdbc/build.xml
@@ -14,7 +14,6 @@
     <pathelement location="${quarks.lib}/quarks.connectors.common.jar" />
   </path>
 
-
   <path id="test.compile.classpath">
     <pathelement location="${jar}" />
     <pathelement location="${quarks.lib}/quarks.providers.direct.jar"/>
@@ -28,7 +27,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/kafka/build.xml
+++ b/connectors/kafka/build.xml
@@ -15,7 +15,6 @@
     <path refid="quarks.ext.classpath" />
   </path>
 
-
   <path id="test.compile.classpath">
     <pathelement location="${jar}" />
     <pathelement location="${quarks.lib}/quarks.providers.direct.jar"/>
@@ -28,7 +27,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/connectors/mqtt/build.xml
+++ b/connectors/mqtt/build.xml
@@ -17,7 +17,6 @@
     <pathelement location="${component.ext}/org.eclipse.paho.client.mqttv3-1.0.2.jar"/>
   </path>
 
-
   <path id="test.compile.classpath">
     <pathelement location="${jar}" />
     <pathelement location="${quarks.lib}/quarks.providers.direct.jar"/>
@@ -31,7 +30,7 @@
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
     <path refid="quarks.ext.classpath" />
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/console/server/build.xml
+++ b/console/server/build.xml
@@ -26,6 +26,7 @@
 	<path id="test.classpath">
 		<pathelement location="${test.classes}" />
 		<path refid="test.compile.classpath" />
+	    <path refid="test.common.classpath" />
 	</path>
 
 </project>

--- a/console/servlets/build.xml
+++ b/console/servlets/build.xml
@@ -43,6 +43,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath" />
+    <path refid="test.common.classpath" />
   </path>
 
 </project>

--- a/providers/development/build.xml
+++ b/providers/development/build.xml
@@ -23,7 +23,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/providers/direct/build.xml
+++ b/providers/direct/build.xml
@@ -25,7 +25,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/runtime/etiao/build.xml
+++ b/runtime/etiao/build.xml
@@ -22,7 +22,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/runtime/jmxcontrol/build.xml
+++ b/runtime/jmxcontrol/build.xml
@@ -21,7 +21,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/samples/apps/build.xml
+++ b/samples/apps/build.xml
@@ -25,6 +25,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
 </project>

--- a/samples/connectors/build.xml
+++ b/samples/connectors/build.xml
@@ -26,7 +26,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/samples/console/build.xml
+++ b/samples/console/build.xml
@@ -23,7 +23,7 @@
 	<path id="test.classpath">
 		<pathelement location="${test.classes}" />
 		<path refid="test.compile.classpath" />
+	    <path refid="test.common.classpath" />
 	</path>
-
 
 </project>

--- a/samples/topology/build.xml
+++ b/samples/topology/build.xml
@@ -22,7 +22,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/samples/utils/build.xml
+++ b/samples/utils/build.xml
@@ -21,6 +21,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
 </project>

--- a/spi/graph/build.xml
+++ b/spi/graph/build.xml
@@ -20,7 +20,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/spi/topology/build.xml
+++ b/spi/topology/build.xml
@@ -18,7 +18,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
-
 
 </project>

--- a/test/svt/build.xml
+++ b/test/svt/build.xml
@@ -25,6 +25,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
 </project>

--- a/utils/metrics/build.xml
+++ b/utils/metrics/build.xml
@@ -22,6 +22,7 @@
   <path id="test.classpath">
     <pathelement location="${test.classes}" />
     <path refid="test.compile.classpath"/>
+    <path refid="test.common.classpath" />
   </path>
 
 </project>


### PR DESCRIPTION
This fixes error messages such as : `[junit] SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".` during unit testing.
