### PR TITLE
address comments on #83

### DIFF
--- a/api/execution/src/main/java/quarks/execution/Configs.java
+++ b/api/execution/src/main/java/quarks/execution/Configs.java
@@ -1,0 +1,33 @@
+package quarks.execution;
+
+/**
+ * Configuration property names.
+ * 
+ * Configuration is passed as a JSON collection of name/value pairs when an executable is 
+ * {@linkplain quarks.execution.Submitter#submit(Object, com.google.gson.JsonObject) submitted}.
+ * <p>
+ * The configuration JSON representation is summarized in the following table:
+ *
+ * <table border=1 cellpadding=3 cellspacing=1>
+ * <caption>Summary of configuration properties</caption>
+ * <tr>
+ *    <td align=center><b>Attribute name</b></td>
+ *    <td align=center><b>Type</b></td>
+ *    <td align=center><b>Description</b></td>
+ *  </tr>
+ * <tr>
+ *    <td>{@link #JOB_NAME}</td>
+ *    <td>String</td>
+ *    <td>The name of the job.</td>
+ *  </tr>
+ * </table>
+ * </p>
+ */
+public interface Configs {
+    /**
+     * JOB_NAME is used to identify the submission configuration property 
+     * containing the job name.
+     * The value is {@value}.
+     */
+    public static final String JOB_NAME = "jobName";
+}

--- a/api/execution/src/main/java/quarks/execution/Job.java
+++ b/api/execution/src/main/java/quarks/execution/Job.java
@@ -94,8 +94,9 @@ public interface Job {
     void stateChange(Action action) throws IllegalArgumentException;
     
     /**
-     * Returns the name of this job. The name is set when the job is 
-     * {@link quarks.execution.Submitter#submit(java.lang.Object,com.google.gson.JsonObject) submitted}.
+     * Returns the name of this job. The name may be set when the job is 
+     * {@linkplain quarks.execution.Submitter#submit(java.lang.Object,com.google.gson.JsonObject) submitted}.
+     * Implementations may create a job name if one is not specified at submit time.
      *
      * @return the job name.
      */

--- a/api/execution/src/main/java/quarks/execution/Submitter.java
+++ b/api/execution/src/main/java/quarks/execution/Submitter.java
@@ -35,7 +35,7 @@ public interface Submitter<E, J extends Job> {
      * Submit an executable.
      * 
      * @param executable executable to submit
-     * @param config context information for the submission
+     * @param config context {@linkplain quarks.execution.Configs information} for the submission
      * @return a future for the submitted executable
      */
     Future<J> submit(E executable, JsonObject config);

--- a/providers/direct/src/main/java/quarks/providers/direct/DirectProvider.java
+++ b/providers/direct/src/main/java/quarks/providers/direct/DirectProvider.java
@@ -38,13 +38,6 @@ public class DirectProvider extends AbstractTopologyProvider<DirectTopology>
 
     private final ServiceContainer services;
     
-    /**
-     * CONFIGURATION_JOB_NAME is used to identify the submission configuration property containing the job name.
-     * The value is {@value}.
-     * @see #submit(Topology, JsonObject)
-     */
-    public static final String CONFIGURATION_JOB_NAME = "jobName";
-
     public DirectProvider() {
         this.services = new ServiceContainer();
     }
@@ -71,26 +64,6 @@ public class DirectProvider extends AbstractTopologyProvider<DirectTopology>
         return submit(topology, new JsonObject());
     }
     
-    /**
-     * {@inheritDoc}
-     * <p>
-     * The configuration JSON representation is summarized in the following table:
-     * 
-     * <table border=1 cellpadding=3 cellspacing=1>
-     * <caption>Summary of configuration properties</caption>
-     * <tr>
-     *    <td align=center><b>Attribute</b></td>
-     *    <td align=center><b>Type</b></td>
-     *    <td align=center><b>Description</b></td>
-     *  </tr>
-     * <tr>
-     *    <td>jobName</td>
-     *    <td>String</td>
-     *    <td>The name of the job.</td>
-     *  </tr>
-     * </table>
-     * 
-     */
     @Override
     public Future<Job> submit(Topology topology, JsonObject config) {
         return ((DirectTopology) topology).executeCallable(config);

--- a/providers/direct/src/main/java/quarks/providers/direct/DirectTopology.java
+++ b/providers/direct/src/main/java/quarks/providers/direct/DirectTopology.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 
+import quarks.execution.Configs;
 import quarks.execution.Job;
 import quarks.execution.services.RuntimeServices;
 import quarks.execution.services.ServiceContainer;
@@ -75,7 +76,7 @@ public class DirectTopology extends GraphTopology<DirectTester> {
         
         JsonElement value = null;
         if (config != null) 
-            value = config.get(DirectProvider.CONFIGURATION_JOB_NAME);
+            value = config.get(Configs.JOB_NAME);
         if (value != null && !(value instanceof JsonNull))
             ((EtiaoJob)getJob()).setName(value.getAsString()); 
         return getExecutable().getScheduler().submit(getCallable());

--- a/providers/direct/src/test/java/quarks/test/providers/direct/DirectJobTest.java
+++ b/providers/direct/src/test/java/quarks/test/providers/direct/DirectJobTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 
 import com.google.gson.JsonObject;
 
+import quarks.execution.Configs;
 import quarks.execution.Job;
 import quarks.graph.Vertex;
 import quarks.oplet.Oplet;
@@ -30,8 +31,6 @@ import quarks.test.topology.TopologyAbstractTest;
 import quarks.topology.TStream;
 import quarks.topology.Topology;
 
-// TODO factor out job submission, waiting for completion
-// TODO create test in quarks.test.runtime.embedded 
 public class DirectJobTest extends TopologyAbstractTest implements DirectTestSetup {
     @Test
     public void jobName0() throws Exception {
@@ -49,7 +48,9 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         String topologyName = "topoName";
         Topology t = newTopology(topologyName);
         t.strings(data);
-        Job job = awaitCompleteExecution(t, new Configuration().addProperty(DirectProvider.CONFIGURATION_JOB_NAME, (String)null).json());
+        JsonObject config = new JsonObject();
+        config.addProperty(Configs.JOB_NAME, (String)null);
+        Job job = awaitCompleteExecution(t, config);
         assertTrue(job.getName().startsWith(topologyName));
     }
 
@@ -59,7 +60,9 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
         String jobName = "testJob";
         Topology t = newTopology();
         t.strings(data);
-        Job job = awaitCompleteExecution(t, new Configuration().addProperty(DirectProvider.CONFIGURATION_JOB_NAME, jobName).json());
+        JsonObject config = new JsonObject();
+        config.addProperty(Configs.JOB_NAME, jobName);
+        Job job = awaitCompleteExecution(t, config);
         assertEquals(jobName, job.getName());
     }
 
@@ -294,19 +297,6 @@ public class DirectJobTest extends TopologyAbstractTest implements DirectTestSet
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }
-        }
-    }
-    
-    private static class Configuration {
-        private final JsonObject values = new JsonObject();
-
-        Configuration addProperty(String name, String value) {
-            values.addProperty(name, value);
-            return this;
-        }
-        
-        JsonObject json() {
-            return values;
         }
     }
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
@@ -28,16 +28,24 @@ public class EtiaoJob extends AbstractGraphJob implements JobContext {
     
     private final DirectGraph graph;
     private final String id;
-    private final String applicationName;
+    private final String topologyName;
     private String name;
     private final ServiceContainer containerServices;
 
     private static final AtomicInteger jobID = new AtomicInteger(0);
 
-    public EtiaoJob(DirectGraph graph, String applicationName, ServiceContainer container) {
+    /**
+     * Creates a new {@code EtiaoJob} instance which controls the lifecycle 
+     * of the specified graph.
+     * 
+     * @param graph graph representation of the topology
+     * @param topologyName name of the topology
+     * @param container service container
+     */
+    public EtiaoJob(DirectGraph graph, String topologyName, ServiceContainer container) {
         this.graph = graph;
         this.id = ID_PREFIX + String.valueOf(jobID.getAndIncrement());
-        this.applicationName = applicationName;
+        this.topologyName = topologyName;
         this.containerServices = container;
 
         ControlService cs = container.getService(ControlService.class);
@@ -45,9 +53,16 @@ public class EtiaoJob extends AbstractGraphJob implements JobContext {
             cs.registerControl(JobMXBean.TYPE, getId(), null, JobMXBean.class, new EtiaoJobBean(this));
     }
 
+    /**
+     * {@inheritDoc}
+     * <P>
+     * If a job name is not specified at submit time, this implementation 
+     * creates a job name with the following format: {@code topologyName_jobId}.
+     * </P>
+     */
     @Override
     public String getName() {
-        return name != null ? name : applicationName + "_" + this.id;
+        return name != null ? name : topologyName + "_" + this.id;
     }
 
     @Override


### PR DESCRIPTION
- new Configs interface for configuration properties
- fluent Configuration helper removed from JUnit tests
- Documentation added for the generated EtiaoJob job name when a name is not submitted 
- DirectJobTest calls t.strings() with no args
