### PR TITLE
Allow a TStream to be terminated with a Sink oplet

### DIFF
--- a/api/oplet/src/main/java/quarks/oplet/core/Sink.java
+++ b/api/oplet/src/main/java/quarks/oplet/core/Sink.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.List;
 
 import quarks.function.Consumer;
+import quarks.function.Functions;
 
 /**
  * Sink a stream by processing each tuple through
@@ -24,16 +25,25 @@ public class Sink<T> extends AbstractOplet<T, Void> {
     private Consumer<T> sinker;
 
     /**
+     * Create a  {@code Sink} that discards all tuples.
+     * The sink function can be changed using
+     * {@link #setSinker(Consumer)}.
+     */
+    public Sink() {
+        setSinker(Functions.discard());
+    }
+    
+    /**
      * Create a {@code Sink} oplet.
      * @param sinker Processing to be performed on each tuple.
      */
     public Sink(Consumer<T> sinker) {
-        this.sinker = sinker;
+        setSinker(sinker);
     }
 
     @Override
     public List<Consumer<T>> getInputs() {
-        return Collections.singletonList(sinker);
+        return Collections.singletonList(getSinker());
     }
 
     @Override
@@ -42,6 +52,22 @@ public class Sink<T> extends AbstractOplet<T, Void> {
     
     @Override
     public void close() throws Exception {
-        closeFunction(sinker);
+        closeFunction(getSinker());
+    }
+    
+    /**
+     * Set the sink function.
+     * @param sinker Processing to be performed on each tuple.
+     */
+    protected void setSinker(Consumer<T> sinker) {
+        this.sinker = sinker;
+    }
+    
+    /**
+     * Get the sink function that processes each tuple.
+     * @return function that processes each tuple.
+     */
+    protected Consumer<T> getSinker() {
+        return sinker;
     }
 }

--- a/api/topology/src/main/java/quarks/topology/TStream.java
+++ b/api/topology/src/main/java/quarks/topology/TStream.java
@@ -14,6 +14,7 @@ import quarks.function.Predicate;
 import quarks.function.ToIntFunction;
 import quarks.function.UnaryOperator;
 import quarks.oplet.core.Pipe;
+import quarks.oplet.core.Sink;
 
 /**
  * A {@code TStream} is a declaration of a continuous sequence of tuples. A
@@ -208,7 +209,7 @@ public interface TStream<T> extends TopologyElement {
     TStream<T> peek(Consumer<T> peeker);
 
     /**
-     * Sink (terminate) this stream. For each tuple {@code t} on this stream
+     * Sink (terminate) this stream using a function. For each tuple {@code t} on this stream
      * {@link Consumer#accept(Object) sinker.accept(t)} will be called. This is
      * typically used to send information to external systems, such as databases
      * or dashboards.
@@ -233,6 +234,18 @@ public interface TStream<T> extends TopologyElement {
      * @return sink element representing termination of this stream.
      */
     TSink<T> sink(Consumer<T> sinker);
+    
+    /**
+     * Sink (terminate) this stream using a oplet.
+     * This provides a richer api for a sink than
+     * {@link #sink(Consumer)} with a full life-cycle of
+     * the oplet as well as easy access to
+     * {@link quarks.execution.services.RuntimeServices runtime services}.
+     * 
+     * @param oplet Oplet processes each tuple without producing output.
+     * @return sink element representing termination of this stream.
+     */
+    TSink<T> sink(Sink<T> oplet);
 
     /**
      * Declare a stream that contains the output of the specified {@link Pipe}

--- a/spi/topology/src/main/java/quarks/topology/spi/AbstractTStream.java
+++ b/spi/topology/src/main/java/quarks/topology/spi/AbstractTStream.java
@@ -6,7 +6,10 @@ package quarks.topology.spi;
 
 import java.util.Collections;
 
+import quarks.function.Consumer;
+import quarks.function.Functions;
 import quarks.function.UnaryOperator;
+import quarks.oplet.core.Sink;
 import quarks.topology.TSink;
 import quarks.topology.TStream;
 import quarks.topology.Topology;
@@ -120,5 +123,10 @@ public abstract class AbstractTStream<G extends Topology, T> implements TStream<
     @Override
     public TStream<T> union(TStream<T> other) {
         return union(Collections.singleton(other));
+    }
+    
+    @Override
+    public TSink<T> sink(Consumer<T> sinker) {
+        return sink(new Sink<>(Functions.synchronizedConsumer(sinker)));
     }
 }

--- a/spi/topology/src/main/java/quarks/topology/spi/graph/ConnectorStream.java
+++ b/spi/topology/src/main/java/quarks/topology/spi/graph/ConnectorStream.java
@@ -101,11 +101,10 @@ public class ConnectorStream<G extends Topology, T> extends AbstractTStream<G, T
         connector.peek(new Peek<T>(peeker));
         return this;
     }
-
+    
     @Override
-    public TSink<T> sink(Consumer<T> sinker) {
-        sinker = Functions.synchronizedConsumer(sinker);
-        Vertex<Sink<T>, T, Void> sinkVertex = graph().insert(new Sink<>(sinker), 1, 0);
+    public TSink<T> sink(Sink<T> oplet) {
+        Vertex<Sink<T>, T, Void> sinkVertex = graph().insert(oplet, 1, 0);
         connector.connect(sinkVertex, 0);
         return new ConnectorSink<>(this);
     }


### PR DESCRIPTION
Expose the richer oplet api to terminate a stream.

Needed for #92
