### PR TITLE
Rename JobContext methods

### DIFF
--- a/api/oplet/src/main/java/quarks/oplet/JobContext.java
+++ b/api/oplet/src/main/java/quarks/oplet/JobContext.java
@@ -12,11 +12,11 @@ public interface JobContext {
      * Get the runtime identifier for the job containing this {@link Oplet}.
      * @return The job identifier for the application being executed.
      */
-    String getJobId();
+    String getId();
     
     /**
      * Get the name of the job containing this {@link Oplet}.
      * @return The job name for the application being executed.
      */
-    String getJobName();
+    String getName();
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/AbstractContext.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/AbstractContext.java
@@ -47,7 +47,7 @@ public abstract class AbstractContext<I, O> implements OpletContext<I, O> {
     public String uniquify(String name) {
         return new StringBuilder(name).
                 append('.').append(OpletContext.class.getPackage().getName()).
-                append('.').append(getJobContext().getJobId()).
+                append('.').append(getJobContext().getId()).
                 append('.').append(getId()).toString();
     }
 }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/EtiaoJob.java
@@ -165,16 +165,6 @@ public class EtiaoJob extends AbstractGraphJob implements JobContext {
         }
     }
 
-    @Override
-    public String getJobId() {
-        return getId();
-    }
-
-    @Override
-    public String getJobName() {
-        return getName();
-    }
-    
     public DirectGraph graph() {
         return graph;
     }

--- a/runtime/etiao/src/main/java/quarks/runtime/etiao/Executable.java
+++ b/runtime/etiao/src/main/java/quarks/runtime/etiao/Executable.java
@@ -170,8 +170,8 @@ public class Executable implements RuntimeServices {
                 // TODO log, don't rethrow
                 t.printStackTrace();
             } finally {
-                jobServices.cleanOplet(job.getJobId(), invocation.getId());
-                job.getContainerServices().cleanOplet(job.getJobId(), invocation.getId());
+                jobServices.cleanOplet(job.getId(), invocation.getId());
+                job.getContainerServices().cleanOplet(job.getId(), invocation.getId());
             }
         });
 


### PR DESCRIPTION
Related to [Etiao multiple id and name methods](https://github.com/quarks-edge/quarks.documentation/issues/50) issue.

Methods JobContext.getJobName() and getJobId() have been renamed to getName() and getId().
